### PR TITLE
Adds strict password generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /node_modules
 npm-debug.log
+.idea
+coverage/

--- a/README.md
+++ b/README.md
@@ -48,3 +48,4 @@ Any of these can be passed into the options object for each function.
 | symbols                  | Boolean, put symbols in password.           |     false     |
 | uppercase                | Boolean, use uppercase letters in password. |      true     |
 | excludeSimilarCharacters | Excludes similar chars, like 'i' and 'l'.   |     false     |
+| strict                   | Generated password must include at least one character from each pool. |     false     |

--- a/example.js
+++ b/example.js
@@ -5,7 +5,8 @@ var password = generator.generate({
 	length: 15, // defaults to 10
 	numbers: true, // defaults to false
 	symbols: true, // defaults to false
-	uppercase: true // defaults to true
+	uppercase: true, // defaults to true
+	strict: true // defaults to false
 });
 
 // Generate ten bulk.

--- a/test/generator.js
+++ b/test/generator.js
@@ -12,6 +12,61 @@ describe('generate-password', function() {
 
 			assert.equal(password.length, length);
 		});
+
+		it('should generate strict random sequence that is correct length', function() {
+			var length = 12;
+
+			var password = generator.generate({length: length, strict: true});
+
+			assert.equal(password.length, length);
+		});
+
+		it('should remove possible similar characters from the sequences', function() {
+			var password = generator.generate({length: 10000, excludeSimilarCharacters: true});
+
+			assert.equal(/[ilLI|`oO0]/.test(password), false);
+		});
+
+		it('should generate strict random sequence that has strictly at least one number', function() {
+			var hasNumber = /[0-9]/;
+
+			var password = generator.generate({length: 12, strict: true, uppercase: false, numbers: true});
+
+			assert.equal(hasNumber.test(password), true);
+		});
+
+		it('should generate strict random sequence that has strictly at least one lowercase letter', function() {
+			var hasLowerCaseLetters = /[a-z]/;
+
+			var password = generator.generate({length: 1, strict: true, uppercase: false});
+
+			assert.equal(hasLowerCaseLetters.test(password), true);
+		});
+
+		it('should generate strict random sequence that has strictly at least one uppercase letter', function() {
+			var hasUpperCaseLetters = /[A-Z]/;
+
+			var password = generator.generate({length: 12, strict: true, uppercase: true});
+
+			assert.equal(hasUpperCaseLetters.test(password), true);
+		});
+
+		it('should generate strict random sequence that has strictly at least one special symbol', function() {
+			var hasSymbols = /(!|@|#|\$|%|\^|&|\*|\(|\)|\+|_|\-|=|}|\{|\[|]|\||:|;|"|\/|\?|\.|>|<|,|`|~|)/;
+
+			var password = generator.generate({length: 12, strict: true, symbols: true});
+			assert.equal(hasSymbols.test(password), true);
+		});
+
+		it('should throw an error if rules don\'t correlate with length', function() {
+			var methodThatThrows = generator.generate.bind(generator, {length: 2, strict: true, symbols: true, numbers: true});
+			assert.throws(methodThatThrows, TypeError, 'Length must correlate with strict guidelines');
+		});
+
+		it('should generate short strict passwords without stack overflow', function(){
+			var passwordGen = generator.generate.bind(generator, {length: 4, strict: true, uppercase: true, numbers: true, symbols: true});
+			assert.doesNotThrow(passwordGen, Error);
+		});
 	});
 
 	describe('generateMultiple()', function() {


### PR DESCRIPTION
When strict password generation is turned on, it will treat the options
as rules: this means that if the uppercase option is turned on, the
resulting password MUST have an uppercase letter inside of it. The same
works with symbols and numbers.

This will allow compliance with some requirements, where passwords must
contain at least one number, one symbol, etc.

However, it must be noted that although turning on strict password
generation seems like it would increase security, it will theoretically
reduce the entropy of the given password.

This is @Algiras's work from https://github.com/brendanashworth/generate-password/pull/7, including touch ups.