### PR TITLE
Accept to generate when called without the options parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,9 @@ $ npm install generate-password --save
 
 ## Usage
 
-#### `generate(options)`
+#### `generate([options])`
 
-Generate one password with the given options. If the options parameter is not
-provided, defaults are used (see Available options below).  Returns a string.
+Generate one password with the given options. Returns a string.
 
 ```javascript
 var generator = require('generate-password');
@@ -29,11 +28,9 @@ var password = generator.generate({
 console.log(password);
 ```
 
-#### `generateMultiple(amount, options)`
+#### `generateMultiple(amount[, options])`
 
-Bulk generate multiple passwords at once, with the same options for all. If the
-options parameter is not provided, defaults are used (see Available options
-below).  Returns an array.
+Bulk generate multiple passwords at once, with the same options for all.  Returns an array.
 
 ```javascript
 var generator = require('generate-password');

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ console.log(password);
 
 #### `generateMultiple(amount[, options])`
 
-Bulk generate multiple passwords at once, with the same options for all.  Returns an array.
+Bulk generate multiple passwords at once, with the same options for all. Returns an array.
 
 ```javascript
 var generator = require('generate-password');

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ $ npm install generate-password --save
 
 #### `generate(options)`
 
-Generate one password with the given options. Returns a string.
+Generate one password with the given options. If the options parameter is not
+provided, defaults are used (see Available options below).  Returns a string.
 
 ```javascript
 var generator = require('generate-password');
@@ -30,7 +31,9 @@ console.log(password);
 
 #### `generateMultiple(amount, options)`
 
-Bulk generate multiple passwords at once, with the same options for all. Returns an array.
+Bulk generate multiple passwords at once, with the same options for all. If the
+options parameter is not provided, defaults are used (see Available options
+below).  Returns an array.
 
 ```javascript
 var generator = require('generate-password');

--- a/src/generate.js
+++ b/src/generate.js
@@ -54,6 +54,7 @@ var generate = function(options, pool) {
 // Generate a random password.
 self.generate = function(options) {
 	// Set defaults.
+	options = options || {};
 	if (!options.hasOwnProperty('length')) options.length = 10;
 	if (!options.hasOwnProperty('numbers')) options.numbers = false;
 	if (!options.hasOwnProperty('symbols')) options.symbols = false;

--- a/test/generator.js
+++ b/test/generator.js
@@ -6,6 +6,11 @@ var generator = process.env.JSCOV ? require('../src-cov/generate') : require('..
 
 describe('generate-password', function() {
 	describe('generate()', function() {
+		it('should accept to be called without the options parameter', function() {
+			assert.doesNotThrow(function () {
+				generator.generate();
+			});
+		});
 		it('should give password of correct length', function() {
 			var length = 12;
 
@@ -87,11 +92,16 @@ describe('generate-password', function() {
 	});
 
 	describe('generateMultiple()', function() {
+		it('should accept to be called without the options parameter', function() {
+			assert.doesNotThrow(function () {
+				generator.generateMultiple(1)
+			});
+		});
 		// should give right amount
 		it('should give right amount of passwords', function() {
 			var amount = 34;
 
-			var passwords = generator.generateMultiple(amount, {});
+			var passwords = generator.generateMultiple(amount);
 
 			assert.equal(passwords.length, amount);
 		});

--- a/test/generator.js
+++ b/test/generator.js
@@ -94,7 +94,7 @@ describe('generate-password', function() {
 	describe('generateMultiple()', function() {
 		it('should accept to be called without the options parameter', function() {
 			assert.doesNotThrow(function () {
-				generator.generateMultiple(1)
+				generator.generateMultiple(1);
 			});
 		});
 		// should give right amount


### PR DESCRIPTION
When options is not provided, defaults are used. This allow to call
generate() and generateMultiple() without having to provide an empty
options object when defaults are wanted.

README and tests updated accordingly. package.json's version left as-is.