### PR TITLE
Custom Symbols Pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Any of these can be passed into the options object for each function.
 | length                   | Integer, length of password.                        |       10      |
 | numbers                  | Boolean, put numbers in password.                   |     false     |
 | symbols                  | Boolean, put symbols in password.                   |     false     |
-| excludes				 				 | String, characters to be excluded from password.		 |      null  	 |
 | uppercase                | Boolean, use uppercase letters in password.         |      true     |
 | excludeSimilarCharacters | Boolean, exclude similar chars, like 'i' and 'l'.   |     false     |
+| excludes                 | String, characters to be excluded from password.    |       ''      |
 | strict                   | Boolean, password must include at least one character from each pool. |     false     |

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Any of these can be passed into the options object for each function.
 | length                   | Integer, length of password.                        |       10      |
 | numbers                  | Boolean, put numbers in password.                   |     false     |
 | symbols                  | Boolean, put symbols in password.                   |     false     |
+| symbolsPool							 | String, custom pool of symbols											 | !@#$%^&*()+_-=}{[]\|:;"/?.><,`~ |
 | uppercase                | Boolean, use uppercase letters in password.         |      true     |
 | excludeSimilarCharacters | Boolean, exclude similar chars, like 'i' and 'l'.   |     false     |
 | strict                   | Boolean, password must include at least one character from each pool. |     false     |

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Any of these can be passed into the options object for each function.
 | length                   | Integer, length of password.                        |       10      |
 | numbers                  | Boolean, put numbers in password.                   |     false     |
 | symbols                  | Boolean, put symbols in password.                   |     false     |
-| symbolsExclusions				 | String, symbols to be excluded from password.			 |      null  	 |
+| excludes				 				 | String, characters to be excluded from password.		 |      null  	 |
 | uppercase                | Boolean, use uppercase letters in password.         |      true     |
 | excludeSimilarCharacters | Boolean, exclude similar chars, like 'i' and 'l'.   |     false     |
 | strict                   | Boolean, password must include at least one character from each pool. |     false     |

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Any of these can be passed into the options object for each function.
 | length                   | Integer, length of password.                        |       10      |
 | numbers                  | Boolean, put numbers in password.                   |     false     |
 | symbols                  | Boolean, put symbols in password.                   |     false     |
-| symbolsPool							 | String, custom pool of symbols											 | !@#$%^&*()+_-=}{[]\|:;"/?.><,`~ |
+| symbolsExclusions				 | String, symbols to be excluded from password.			 |      null  	 |
 | uppercase                | Boolean, use uppercase letters in password.         |      true     |
 | excludeSimilarCharacters | Boolean, exclude similar chars, like 'i' and 'l'.   |     false     |
 | strict                   | Boolean, password must include at least one character from each pool. |     false     |

--- a/src/generate.js
+++ b/src/generate.js
@@ -58,7 +58,7 @@ self.generate = function(options) {
 	if (!options.hasOwnProperty('length')) options.length = 10;
 	if (!options.hasOwnProperty('numbers')) options.numbers = false;
 	if (!options.hasOwnProperty('symbols')) options.symbols = false;
-	if (!options.hasOwnProperty('symbolsPool')) options.symbolsPool = null;
+	if (!options.hasOwnProperty('symbolsExclusions')) options.symbolsExclusions = null;
 	if (!options.hasOwnProperty('uppercase')) options.uppercase = true;
 	if (!options.hasOwnProperty('excludeSimilarCharacters')) options.excludeSimilarCharacters = false;
 	if (!options.hasOwnProperty('strict')) options.strict = false;
@@ -83,8 +83,13 @@ self.generate = function(options) {
 	}
 	// symbols
 	if (options.symbols) {
-		if (options.symbolsPool != null) {
-			pool += options.symbolsPool;
+		if (options.symbolsExclusions != null) {
+			var i = options.symbolsExclusions.length;
+			while (i--) {
+				symbols = symbols.replace(options.symbolsExclusions[i], '');
+			}
+
+			pool += symbols;
 		} else {
 			pool += symbols;
 		}

--- a/src/generate.js
+++ b/src/generate.js
@@ -58,7 +58,7 @@ self.generate = function(options) {
 	if (!options.hasOwnProperty('length')) options.length = 10;
 	if (!options.hasOwnProperty('numbers')) options.numbers = false;
 	if (!options.hasOwnProperty('symbols')) options.symbols = false;
-	if (!options.hasOwnProperty('excludes')) options.excludes = null;
+	if (!options.hasOwnProperty('excludes')) options.excludes = '';
 	if (!options.hasOwnProperty('uppercase')) options.uppercase = true;
 	if (!options.hasOwnProperty('excludeSimilarCharacters')) options.excludeSimilarCharacters = false;
 	if (!options.hasOwnProperty('strict')) options.strict = false;
@@ -92,11 +92,9 @@ self.generate = function(options) {
 	}
 
 	// excludes characters from the pool
-	if (options.excludes != null) {
-		var i = options.excludes.length;
-		while (i--) {
-			pool = pool.replace(options.excludes[i], '');
-		}
+	var i = options.excludes.length;
+	while (i--) {
+		pool = pool.replace(options.excludes[i], '');
 	}
 
 	var password = generate(options, pool);

--- a/src/generate.js
+++ b/src/generate.js
@@ -58,6 +58,7 @@ self.generate = function(options) {
 	if (!options.hasOwnProperty('length')) options.length = 10;
 	if (!options.hasOwnProperty('numbers')) options.numbers = false;
 	if (!options.hasOwnProperty('symbols')) options.symbols = false;
+	if (!options.hasOwnProperty('symbolsPool')) options.symbolsPool = null;
 	if (!options.hasOwnProperty('uppercase')) options.uppercase = true;
 	if (!options.hasOwnProperty('excludeSimilarCharacters')) options.excludeSimilarCharacters = false;
 	if (!options.hasOwnProperty('strict')) options.strict = false;
@@ -82,8 +83,13 @@ self.generate = function(options) {
 	}
 	// symbols
 	if (options.symbols) {
-		pool += symbols;
+		if (options.symbolsPool != null) {
+			pool += options.symbolsPool;
+		} else {
+			pool += symbols;
+		}
 	}
+
 	// similar characters
 	if (options.excludeSimilarCharacters) {
 		pool = pool.replace(similarCharacters, '');

--- a/src/generate.js
+++ b/src/generate.js
@@ -88,11 +88,9 @@ self.generate = function(options) {
 			while (i--) {
 				symbols = symbols.replace(options.symbolsExclusions[i], '');
 			}
-
-			pool += symbols;
-		} else {
-			pool += symbols;
 		}
+
+		pool += symbols;
 	}
 
 	// similar characters

--- a/src/generate.js
+++ b/src/generate.js
@@ -58,7 +58,7 @@ self.generate = function(options) {
 	if (!options.hasOwnProperty('length')) options.length = 10;
 	if (!options.hasOwnProperty('numbers')) options.numbers = false;
 	if (!options.hasOwnProperty('symbols')) options.symbols = false;
-	if (!options.hasOwnProperty('symbolsExclusions')) options.symbolsExclusions = null;
+	if (!options.hasOwnProperty('excludes')) options.excludes = null;
 	if (!options.hasOwnProperty('uppercase')) options.uppercase = true;
 	if (!options.hasOwnProperty('excludeSimilarCharacters')) options.excludeSimilarCharacters = false;
 	if (!options.hasOwnProperty('strict')) options.strict = false;
@@ -83,19 +83,20 @@ self.generate = function(options) {
 	}
 	// symbols
 	if (options.symbols) {
-		if (options.symbolsExclusions != null) {
-			var i = options.symbolsExclusions.length;
-			while (i--) {
-				symbols = symbols.replace(options.symbolsExclusions[i], '');
-			}
-		}
-
 		pool += symbols;
 	}
 
 	// similar characters
 	if (options.excludeSimilarCharacters) {
 		pool = pool.replace(similarCharacters, '');
+	}
+
+	// excludes characters from the pool
+	if (options.excludes != null) {
+		var i = options.excludes.length;
+		while (i--) {
+			pool = pool.replace(options.excludes[i], '');
+		}
 	}
 
 	var password = generate(options, pool);

--- a/test/generator.js
+++ b/test/generator.js
@@ -77,12 +77,12 @@ describe('generate-password', function() {
 				assert.equal(passwords.length, amountToGenerate);
 			});
 
-			it('should generate strict random sequence that has strictly at least one special symbol from the new pool', function() {
+			it('should generate strict random sequence that avoids all exluded characters', function() {
 				var passwords = generator.generateMultiple(amountToGenerate, {length: 4, strict: true, symbols: true, excludes: 'abcdefg+_\-=}{[\]|:;"/?.><,`~'});
 
 				passwords.forEach(function(password) {
-					assert.match(password, /[!@#$%^&*()]/, 'password has a symbol from the new pool');
-					assert.notMatch(password, /[abcdefg+_\-=}{[\]|:;"/?.><,`~]/, 'password does not have an excluded character from the full pool');
+					assert.match(password, /[!@#$%^&*()]/, 'password uses normal symbols');
+					assert.notMatch(password, /[abcdefg+_\-=}{[\]|:;"/?.><,`~]/, 'password avoids excluded characters from the full pool');
 				});
 				assert.equal(passwords.length, amountToGenerate);
 			});

--- a/test/generator.js
+++ b/test/generator.js
@@ -78,11 +78,11 @@ describe('generate-password', function() {
 			});
 
 			it('should generate strict random sequence that has strictly at least one special symbol from the new pool', function() {
-				var passwords = generator.generateMultiple(amountToGenerate, {length: 4, strict: true, symbols: true, symbolsExclusions: '+_\-=}{[\]|:;"/?.><,`~'});
+				var passwords = generator.generateMultiple(amountToGenerate, {length: 4, strict: true, symbols: true, excludes: 'abcdefg+_\-=}{[\]|:;"/?.><,`~'});
 
 				passwords.forEach(function(password) {
 					assert.match(password, /[!@#$%^&*()]/, 'password has a symbol from the new pool');
-					assert.notMatch(password, /[+_\-=}{[\]|:;"/?.><,`~]/, 'password does not have a symbol from the full pool');
+					assert.notMatch(password, /[abcdefg+_\-=}{[\]|:;"/?.><,`~]/, 'password does not have an excluded character from the full pool');
 				});
 				assert.equal(passwords.length, amountToGenerate);
 			});

--- a/test/generator.js
+++ b/test/generator.js
@@ -78,7 +78,7 @@ describe('generate-password', function() {
 			});
 
 			it('should generate strict random sequence that has strictly at least one special symbol from the new pool', function() {
-				var passwords = generator.generateMultiple(amountToGenerate, {length: 4, strict: true, symbols: true, symbolsPool: '!@#$%^&*()'});
+				var passwords = generator.generateMultiple(amountToGenerate, {length: 4, strict: true, symbols: true, symbolsExclusions: '+_\-=}{[\]|:;"/?.><,`~'});
 
 				passwords.forEach(function(password) {
 					assert.match(password, /[!@#$%^&*()]/, 'password has a symbol from the new pool');

--- a/test/generator.js
+++ b/test/generator.js
@@ -77,6 +77,16 @@ describe('generate-password', function() {
 				assert.equal(passwords.length, amountToGenerate);
 			});
 
+			it('should generate strict random sequence that has strictly at least one special symbol from the new pool', function() {
+				var passwords = generator.generateMultiple(amountToGenerate, {length: 4, strict: true, symbols: true, symbolsPool: '!@#$%^&*()'});
+
+				passwords.forEach(function(password) {
+					assert.match(password, /[!@#$%^&*()]/, 'password has a symbol from the new pool');
+					assert.notMatch(password, /[+_\-=}{[\]|:;"/?.><,`~]/, 'password does not have a symbol from the full pool');
+				});
+				assert.equal(passwords.length, amountToGenerate);
+			});
+
 			it('should throw an error if rules don\'t correlate with length', function() {
 				assert.throws(function() {
 					generator.generate({length: 2, strict: true, symbols: true, numbers: true});


### PR DESCRIPTION
Some real-world applications restrict the use of some symbol characters.

I've added a test and config option to provide a customisable pool of symbols.

```
generatePassword.generate({
      length: 10,
      numbers: true,
      symbols: true,
      symbolsPool: '!@#$%^&*()',
      strict: true
    });
```

Would restrict the symbol pool to the smaller provided subset. 