### PR TITLE
Replace crypto with randombytes so it works in browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "url": "https://github.com/brendanashworth/generate-password/issues"
   },
   "homepage": "https://github.com/brendanashworth/generate-password",
-  "dependencies": {},
+  "dependencies": {
+    "randombytes": "^2.0.5"
+  },
   "devDependencies": {
     "chai": "^1.10.0",
     "codecov": "^1.0.1",

--- a/src/generate.js
+++ b/src/generate.js
@@ -1,11 +1,11 @@
-var crypto = require('crypto');
+var randomBytes = require('randombytes');
 
 var self = module.exports;
 
 // Generates a random number
 var randomNumber = function(max) {
 	// gives a number between 0 (inclusive) and max (exclusive)
-	return crypto.randomBytes(1)[0] % max;
+	return randomBytes(1)[0] % max;
 };
 
 // Possible combinations


### PR DESCRIPTION
Possible fix for https://github.com/brendanashworth/generate-password/issues/20#issuecomment-330093666

Note that I have absolutely no clue if this is an appropriate solution.
In my tests this "fix" works in Angular and a `npm test` came back positive.

Works in:
- Google Chrome 60.0.3112.113
- Firefox 55.0.3
- Internet Explorer 11
