### PR TITLE
Changed randomNumber to be no longer biased

### DIFF
--- a/src/generate.js
+++ b/src/generate.js
@@ -5,7 +5,11 @@ var self = module.exports;
 // Generates a random number
 var randomNumber = function(max) {
 	// gives a number between 0 (inclusive) and max (exclusive)
-	return crypto.randomBytes(1)[0] % max;
+	var rand = crypto.randomBytes(1)[0];
+	while (rand >= max - (256 % max)) {
+		rand = crypto.randomBytes(1)[0];
+	}
+	return rand % max;
 };
 
 // Possible combinations

--- a/src/generate.js
+++ b/src/generate.js
@@ -6,7 +6,7 @@ var self = module.exports;
 var randomNumber = function(max) {
 	// gives a number between 0 (inclusive) and max (exclusive)
 	var rand = crypto.randomBytes(1)[0];
-	while (rand >= max - (256 % max)) {
+	while (rand >= 256 - (256 % max)) {
 		rand = crypto.randomBytes(1)[0];
 	}
 	return rand % max;


### PR DESCRIPTION
Before in randomNumber return crypto.randomBytes(1)[0] % max; was used to generate the random number. Using modulo at the end does lead to a bias in the probability distribution of the generated characters if the character count does not divide 256. E.g. if using randomNumber(255) the number 0 is twice as likely as all other numbers and thus the character 'a' will appear much more frequently. 

The fix is to discard the random value if it is above the highest mulitple of the character count that is not greater than 256.