### PR TITLE
Allow lowercase in options

### DIFF
--- a/src/generate.d.ts
+++ b/src/generate.d.ts
@@ -3,6 +3,7 @@ interface Options {
   numbers?: boolean
   symbols?: boolean
   uppercase?: boolean
+  lowercase?: boolean
   excludeSimilarCharacters?: boolean
   exclude?: string
   strict?: boolean


### PR DESCRIPTION
Why?

I use this lib with Typescript. Can't provide `lowercase` option, while it's implemented in the lib, just omitted in options. This may lead to situations where the generated password does not contain lower case signs and does not match password policies