### PR TITLE
respect list of symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,15 +47,15 @@ console.log(passwords);
 ### Available options
 Any of these can be passed into the options object for each function.
 
-|            Name          |                  Description                        | Default Value |
-|--------------------------|-----------------------------------------------------|---------------|
-| length                   | Integer, length of password.                        |       10      |
-| numbers*                 | Boolean, put numbers in password.                   |     false     |
-| symbols*                 | Boolean, put symbols in password.                   |     false     |
-| lowercase*               | Boolean, put lowercase in password                  |      true     |
-| uppercase*               | Boolean, use uppercase letters in password.         |      true     |
-| excludeSimilarCharacters | Boolean, exclude similar chars, like 'i' and 'l'.   |     false     |
-| exclude                  | String, characters to be excluded from password.    |       ''      |
-| strict                   | Boolean, password must include at least one character from each pool. |     false     |
+| Name                     | Description                                                           | Default Value |
+|--------------------------|-----------------------------------------------------------------------|---------------|
+| length                   | Integer, length of password.                                          | 10            |
+| numbers*                 | Boolean, put numbers in password.                                     | false         |
+| symbols*                 | Boolean or String, put symbols in password.                           | false         |
+| lowercase*               | Boolean, put lowercase in password                                    | true          |
+| uppercase*               | Boolean, use uppercase letters in password.                           | true          |
+| excludeSimilarCharacters | Boolean, exclude similar chars, like 'i' and 'l'.                     | false         |
+| exclude                  | String, characters to be excluded from password.                      | ''            |
+| strict                   | Boolean, password must include at least one character from each pool. | false         |
 
 *At least one should be true.

--- a/example.js
+++ b/example.js
@@ -10,6 +10,15 @@ var password = generator.generate({
 	strict: true // defaults to false
 });
 
+// Generate one password with provided list of symbols.
+var password = generator.generate({
+	length: 15, // defaults to 10
+	numbers: true, // defaults to false
+	symbols: "!@#$%&*", // defaults to false
+	uppercase: true, // defaults to true
+	strict: true // defaults to false
+});
+
 // Generate ten bulk.
 var passwords = generator.generateMultiple(10, {
 	length: 15,

--- a/src/generate.js
+++ b/src/generate.js
@@ -57,6 +57,13 @@ var generate = function(options, pool) {
 			// If the option is not checked, ignore it.
 			if (options[rule.name] == false) return true;
 
+			// Treat symbol differently if explicit string is provided
+			if (rule.name === 'symbols' && typeof options[rule.name] === 'string') {
+				// Create a regular expression from the provided symbols
+				var re = new RegExp("["+options[rule.name]+"]");
+				return re.test(password);
+			};
+
 			// Run the regex on the password and return whether
 			// or not it matches.
 			return rule.rule.test(password);
@@ -107,7 +114,11 @@ self.generate = function(options) {
 	}
 	// symbols
 	if (options.symbols) {
-		pool += symbols;
+		if (typeof options.symbols === "string") {
+			pool += options.symbols;
+		} else {
+			pool += symbols;
+		}
 	}
 
 	// Throw error if pool is empty.

--- a/test/generator.js
+++ b/test/generator.js
@@ -108,6 +108,16 @@ describe('generate-password', function() {
 				assert.equal(passwords.length, amountToGenerate);
 			});
 
+			it('should respect explicit list of symbols when provided', function() {
+				var passwords = generator.generateMultiple(amountToGenerate, { length: 10, strict: true, symbols: "!", lowercase: true });
+
+				passwords.forEach(function (password) {
+					assert.notMatch(password, /[@#$%^&*()+_\-=}{[\]|:;"/?.><,`~]/, 'password does not have default symbols');
+					assert.match(password, /[!]/, 'password has provided symbol');
+				});
+				assert.equal(passwords.length, amountToGenerate);
+			});
+
 			it('should throw an error if rules don\'t correlate with length', function() {
 				assert.throws(function() {
 					generator.generate({length: 2, strict: true, symbols: true, numbers: true});


### PR DESCRIPTION
fixes #45 

This PR adds support for optionally providing explicit list of strings for `symbols` parameter.