### PR TITLE
feat: No more than 2 identical characters in a row

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,6 @@ Any of these can be passed into the options object for each function.
 | uppercase*               | Boolean, use uppercase letters in password.         |      true     |
 | excludeSimilarCharacters | Boolean, exclude similar chars, like 'i' and 'l'.   |     false     |
 | exclude                  | String, characters to be excluded from password.    |       ''      |
-| strict                   | Boolean, password must include at least one character from each pool. |     false     |
+| strict                   | Boolean, password must include at least one character from each pool and no more than two identical charactes in a row. |     false     |
 
 *At least one should be true.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "generate-password",
-  "version": "1.4.2",
+  "version": "1.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -221,6 +221,12 @@
         "assertion-error": "1.0.0",
         "deep-eql": "0.1.3"
       }
+    },
+    "chai-spies": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/chai-spies/-/chai-spies-1.0.0.tgz",
+      "integrity": "sha512-elF2ZUczBsFoP07qCfMO/zeggs8pqCf3fZGyK5+2X4AndS8jycZYID91ztD9oQ7d/0tnS963dPkd0frQEThDsg==",
+      "dev": true
     },
     "chalk": {
       "version": "2.4.2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {},
   "devDependencies": {
     "chai": "^1.10.0",
+    "chai-spies": "^1.0.0",
     "codecov": "^1.0.1",
     "eslint": "^6.5.1",
     "jscover": "^1.0.0",

--- a/src/generate.js
+++ b/src/generate.js
@@ -45,13 +45,22 @@ var lowercase = 'abcdefghijklmnopqrstuvwxyz',
 var generate = function(options, pool) {
 	var password = '',
 		optionsLength = options.length,
-		poolLength = pool.length;
+		optionsStrict = options.strict,
+		poolLength = pool.length,
+		char;
 
-	for (var i = 0; i < optionsLength; i++) {
-		password += pool[randomNumber(poolLength)];
+	// if number of iterations exeed 3x (arbitrary) of needed length gave attempt up
+	for (var i = 0; password.length < optionsLength || i > 3 * optionsLength ; i++) {
+		var nextChar = pool[randomNumber(poolLength)];
+		// to avoid three repeated charactes in the row
+		var prevChar = password.slice(-2, -1);
+		if (optionsStrict && (nextChar !== prevChar) || !optionsStrict) {
+			password += nextChar;
+			char = nextChar;
+		}
 	}
 
-	if (options.strict) {
+	if (optionsStrict) {
 		// Iterate over each rule, checking to see if the password works.
 		var fitsRules = strictRules.every(function(rule) {
 			// If the option is not checked, ignore it.

--- a/test/generator.js
+++ b/test/generator.js
@@ -1,8 +1,30 @@
-var assert = require('chai').assert,
-	_ = require('underscore');
+var chai = require('chai'),
+	spies = require('chai-spies'),
+	_ = require('underscore'),
+	crypto = require('crypto');
+
+chai.use(spies);
+var assert = chai.assert;
+const sandbox = chai.spy.sandbox()
 
 // We use a different require path for code coverage.
 var generator = process.env.JSCOV ? require('../src-cov/generate') : require('../main');
+
+// Tests with spies should go before
+describe('generate-password with spy', function() {
+	describe('generate()', function() {
+		beforeEach(() => sandbox.on(crypto, 'randomBytes', () => Buffer.from([26,0,0,0,26])));
+		afterEach(() => sandbox.restore());
+		it('should have more than two same characters next to each other', () => {
+			var password = generator.generate();
+			assert.equal(password, 'AaaaAAaaaA');
+		});
+		it('should not have more than two same characters next to each other', () => {
+			var password = generator.generate({strict: true});
+			assert.equal(password, 'AaaAAaaAAa');
+		});
+	})
+});
 
 describe('generate-password', function() {
 	describe('generate()', function() {


### PR DESCRIPTION
In strict mode only 2 identical characters can appear in the row.
Added `chai-spices` dependency to make tests easier by controling randomness.

The motivation is the Auth0 password policy:
![image](https://user-images.githubusercontent.com/1277279/91652838-a59bf980-ea4f-11ea-998f-aeb94b522887.png)
