### PR TITLE
Fix exports for ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "1.7.0",
   "description": "Easy library for generating unique passwords.",
   "main": "main.js",
-  "exports": "./main.js",
+  "exports": {
+    "types": "./src/generate.d.ts",
+    "default": "./main.js"
+  },
   "types": "src/generate.d.ts",
   "scripts": {
     "test": "./node_modules/.bin/mocha",


### PR DESCRIPTION
When trying to import `generate-password` from a TypeScript project built as ES Module (rather than CommonJS), it gives the error:

```
Could not find a declaration file for module 'generate-password'.
```

My temporary workaround has been to add this to `tsconfig.json`:
```
    "paths": {
      "generate-password": ["./node_modules/generate-password/src/generate.d.ts"]
    },
```

Basically, the types are not declared correctly for consumption by ESM. You can check this on [`Are the Types Wrong?`](https://arethetypeswrong.github.io/?p=generate-password), or using its CLI:

```
npx @arethetypeswrong/cli --pack .
```

This PR updates the `exports` field in `package.json` to something that passes the above check and works in my ESM project (as well as CJS projects).